### PR TITLE
 Replace anonymous class by enclosing class to avoid converter mismatch

### DIFF
--- a/src/main/java/org/vaadin/easybinder/data/ReflectionBinder.java
+++ b/src/main/java/org/vaadin/easybinder/data/ReflectionBinder.java
@@ -233,8 +233,8 @@ public class ReflectionBinder<BEAN> extends BasicBinder<BEAN> implements HasGene
 			Query<?, ?> q = new Query<>(0, 1, null, null, null);
 			if (dp.size((Query) q) > 0) {
 				Optional<Class<PRESENTATION>> presentationClass = hasItems.getDataProvider().fetch((Query) q).findFirst().map(e -> e.getClass());
-				if(presentationClass.get().isAnonymousClass()) {
-					log.log(Level.INFO,"PresentationType represents a anonymous class, fetching enclosing class.");
+				if (presentationClass.get().isAnonymousClass()) {
+					log.log(Level.INFO, "PresentationType represents a anonymous class, fetching enclosing class.");
 					presentationClass = hasItems.getDataProvider().fetch((Query) q).findFirst().map(e -> e.getClass().getEnclosingClass());
 				}
 				return presentationClass;

--- a/src/main/java/org/vaadin/easybinder/data/ReflectionBinder.java
+++ b/src/main/java/org/vaadin/easybinder/data/ReflectionBinder.java
@@ -232,7 +232,12 @@ public class ReflectionBinder<BEAN> extends BasicBinder<BEAN> implements HasGene
 			DataProvider<?, ?> dp = hasItems.getDataProvider();
 			Query<?, ?> q = new Query<>(0, 1, null, null, null);
 			if (dp.size((Query) q) > 0) {
-				return hasItems.getDataProvider().fetch((Query) q).findFirst().map(e -> e.getClass());
+				Optional<Class<PRESENTATION>> presentationClass = hasItems.getDataProvider().fetch((Query) q).findFirst().map(e -> e.getClass());
+				if(presentationClass.get().isAnonymousClass()) {
+					log.log(Level.INFO,"PresentationType represents a anonymous class, fetching enclosing class.");
+					presentationClass = hasItems.getDataProvider().fetch((Query) q).findFirst().map(e -> e.getClass().getEnclosingClass());
+				}
+				return presentationClass;
 			}
 		}
 


### PR DESCRIPTION
Using Enums with anonymous inner classes results in a converter not found error:

ERROR | ReflectionBinder | Unable to find converter between presentationType=<class com.neovisionaries.i18n.CountryCode$1> and modelType=<class com.neovisionaries.i18n.CountryCode> for property=<countryCode>. Please register a converter.

